### PR TITLE
 Make it easier run explorer on a remote host

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,19 @@ Clone the repo, navigate to the cloned directory and run the instance with:
 NODE_ENDPOINT=http://<node_endpoint> docker-compose up
 ```
 Append the `-d` argument to run the containers in the backgroud
+If you run docker(-compose) using `sudo` specify `sudo`'s `-E` option to
+preserve the set environment variables
 
 You will be able to access the Explorer UI via:
 
 * http://localhost:5000
+
+If you want to run the Explorer on a remote server, change the host ip
+so that the js requests from the UI are routed correctly:
+```bash
+NODE_ENDPOINT=http://<node_endpoint> HOST_IP=<ip if the (docker) host running the containers> docker-compose up
+```
+
 
 To stop the containers use:
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ Clone the repo, navigate to the cloned directory and run the instance with:
 ```bash
 NODE_ENDPOINT=http://<node_endpoint> docker-compose up
 ```
-Append the `-d` argument to run the containers in the backgroud
+Append the `-d` argument to run the containers in the backgroud.
+
 If you run docker(-compose) using `sudo` specify `sudo`'s `-E` option to
-preserve the set environment variables
+preserve the set environment variables.
 
 You will be able to access the Explorer UI via:
 
@@ -26,7 +27,7 @@ You will be able to access the Explorer UI via:
 If you want to run the Explorer on a remote server, change the host ip
 so that the js requests from the UI are routed correctly:
 ```bash
-NODE_ENDPOINT=http://<node_endpoint> HOST_IP=<ip if the (docker) host running the containers> docker-compose up
+NODE_ENDPOINT=http://<node_endpoint> HOST_IP=<IP of (docker) host running the containers> docker-compose up
 ```
 
 
@@ -36,10 +37,10 @@ To stop the containers use:
 docker-compose down
 ```
 
-To connect to new network you need to delete one of the containers with:
+To connect to a new network you need to delete one of the containers with:
 
 ```bash
-docker rm blk-mongodb-free
+docker rm blk-free-mongodb
 ```
  
 ### Local Quorum Networks

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "2"
+version: "2.1"
 services:
   REST:
     image: blkio10/explorer-free:2.0.0
@@ -11,7 +11,7 @@ services:
       - NODE_ENDPOINT=${NODE_ENDPOINT}
       - MONGO_CLIENT_URI=mongodb://mongodb:27017
       - MONGO_DB_NAME=test
-      - UI_IP=http://localhost:5000
+      - UI_IP=http://${HOST_IP:-localhost}:5000
       - USE_COSMOS=false
     depends_on:
       - mongodb
@@ -29,4 +29,4 @@ services:
     ports:
       - 5000:5000
     environment:
-      - REACT_APP_EXPLORER=http://localhost:8081
+      - REACT_APP_EXPLORER=http://${HOST_IP:-localhost}:8081


### PR DESCRIPTION
I made the IP in the following env-variables configurable to make it easier to run the Explorer on a remote (docker) host:

- UI_IP
- REACT_APP_EXPLORER

This works since the ports of the explorer and the explorer_ui are exposed to the host

I updated the README to explain how the explorer can be run on a remote host using the new `HOST_IP` env variable